### PR TITLE
[FIX] Cordova 9 adjustment

### DIFF
--- a/hooks/windows/check-arch.js
+++ b/hooks/windows/check-arch.js
@@ -6,8 +6,8 @@ module.exports = context => {
 	if( context.opts && context.opts.platforms && context.opts.platforms.indexOf( "windows" ) > -1 &&
 		context.opts.options ) {
 		const path  = require( "path" );
-		const shell = context.requireCordovaModule( "shelljs" );
-		const nopt  = context.requireCordovaModule( "nopt" );
+		const shell = require( "shelljs" );
+		const nopt  = require( "nopt" );
 
 		// parse and validate args
 		const args = nopt( {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "eslint": "4.12.0",
     "eslint-plugin-promise": "3.6.0",
     "jasmine-node": "1.14.5",
-    "pluginpub": "^0.0.9"
+    "nopt":"4.0.1",
+    "pluginpub": "^0.0.9",
+    "shelljs":"0.8.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Cordova 9 disallows the usage of `context.requireCordovaModule(...)` in
hooks to require non-cordova modules.